### PR TITLE
Fix instance types

### DIFF
--- a/coqlspclient/proof_state.py
+++ b/coqlspclient/proof_state.py
@@ -278,14 +278,6 @@ class ProofState(object):
                 last_term = term
         return last_term
 
-    def __get_instance_context(self):
-        term = self.__get_last_term()
-        instance_expr = CoqFile.expr(term.ast)
-        class_id = CoqFile.get_id(instance_expr[3]["v"][1]["v"][1]["v"])
-        class_term = self.__get_term(class_id)
-        statement_context = self.__step_context() + self.__step_context(class_term.ast)
-        return term, statement_context
-
     def __get_program_context(self):
         def traverse_ast(el, keep_id=False):
             if (
@@ -376,8 +368,6 @@ class ProofState(object):
         term, statement_context = None, None
         if CoqFile.get_term_type(self.__current_step.ast) == TermType.OBLIGATION:
             term, statement_context = self.__get_program_context()
-        elif CoqFile.get_term_type(self.__current_step.ast) == TermType.INSTANCE:
-            term, statement_context = self.__get_instance_context()
         elif CoqFile.get_term_type(self.__current_step.ast) != TermType.OTHER:
             term = self.__get_last_term()
             statement_context = self.__step_context()

--- a/tests/resources/test_type_class.v
+++ b/tests/resources/test_type_class.v
@@ -3,6 +3,7 @@ Class EqDecNew (A : Type) :=
 { eqb_new : A -> A -> bool ;
   eqb_leibniz_new : forall x y, eqb_new x y = true -> x = y ;
   eqb_ident_new : forall x, eqb_new x x = true }.
+End TypeClass.
 
 #[refine] Global Instance unit_EqDec : TypeClass.EqDecNew unit := { eqb_new x y := true }.
 Proof.

--- a/tests/resources/test_type_class.v
+++ b/tests/resources/test_type_class.v
@@ -3,10 +3,18 @@ Class EqDecNew (A : Type) :=
 { eqb_new : A -> A -> bool ;
   eqb_leibniz_new : forall x y, eqb_new x y = true -> x = y ;
   eqb_ident_new : forall x, eqb_new x x = true }.
-End TypeClass.
 
 #[refine] Global Instance unit_EqDec : TypeClass.EqDecNew unit := { eqb_new x y := true }.
 Proof.
 intros [] []; reflexivity.
 intros []; reflexivity.
 Defined.
+
+Section test.
+
+Instance test : TypeClass.EqDecNew unit -> TypeClass.EqDecNew unit.
+Proof.
+  auto.
+Defined.
+
+End test.

--- a/tests/test_proof_state.py
+++ b/tests/test_proof_state.py
@@ -533,14 +533,14 @@ def test_module_type(setup, teardown):
 
 @pytest.mark.parametrize("setup", [("test_type_class.v", None)], indirect=True)
 def test_type_class(setup, teardown):
-    assert len(state.proofs) == 1
+    assert len(state.proofs) == 2
     assert len(state.proofs[0].steps) == 2
     assert (
         state.proofs[0].text
         == "#[refine] Global Instance unit_EqDec : TypeClass.EqDecNew unit := { eqb_new x y := true }."
     )
 
-    class_context = [
+    context = [
         (
             "Class EqDecNew (A : Type) := { eqb_new : A -> A -> bool ; eqb_leibniz_new : forall x y, eqb_new x y = true -> x = y ; eqb_ident_new : forall x, eqb_new x x = true }.",
             TermType.CLASS,
@@ -552,11 +552,25 @@ def test_type_class(setup, teardown):
             TermType.INDUCTIVE,
             [],
         ),
+    ]
+    compare_context(context, state.proofs[0].context)
+
+    assert (
+        state.proofs[1].text
+        == "Instance test : TypeClass.EqDecNew unit -> TypeClass.EqDecNew unit."
+    )
+
+    context = [
         (
             'Notation "A -> B" := (forall (_ : A), B) : type_scope.',
             TermType.NOTATION,
-            [],
+            []
         ),
-        ('Notation "x = y :> A" := (@eq A x y) : type_scope', TermType.NOTATION, []),
+        (
+            "Class EqDecNew (A : Type) := { eqb_new : A -> A -> bool ; eqb_leibniz_new : forall x y, eqb_new x y = true -> x = y ; eqb_ident_new : forall x, eqb_new x x = true }.",
+            TermType.CLASS,
+            ["TypeClass"],
+        ),
+        ("Inductive unit : Set := tt : unit.", TermType.INDUCTIVE, []),
     ]
-    compare_context(class_context, state.proofs[0].context)
+    compare_context(context, state.proofs[1].context)

--- a/tests/test_proof_state.py
+++ b/tests/test_proof_state.py
@@ -564,7 +564,7 @@ def test_type_class(setup, teardown):
         (
             'Notation "A -> B" := (forall (_ : A), B) : type_scope.',
             TermType.NOTATION,
-            []
+            [],
         ),
         (
             "Class EqDecNew (A : Type) := { eqb_new : A -> A -> bool ; eqb_leibniz_new : forall x y, eqb_new x y = true -> x = y ; eqb_ident_new : forall x, eqb_new x x = true }.",


### PR DESCRIPTION
Previously, the code considered that the type of an instance was by definition the id of a class, but something like `TypeClass.EqDecNew unit -> TypeClass.EqDecNew unit` is allowed.